### PR TITLE
Fix import paths to use github repo paths

### DIFF
--- a/cmd/typogen/main.go
+++ b/cmd/typogen/main.go
@@ -7,9 +7,9 @@ import (
 
 	"golang.org/x/net/idna"
 
-	"zenithar.org/go/typogenerator"
-	"zenithar.org/go/typogenerator/mapping"
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator"
+	"github.com/Zenithar/typogenerator/mapping"
+	"github.com/Zenithar/typogenerator/strategy"
 
 	"github.com/hduplooy/gocsv"
 	"github.com/namsral/flag"

--- a/fuzzer.go
+++ b/fuzzer.go
@@ -1,7 +1,7 @@
 package typogenerator
 
 import (
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 // FuzzResult represents permutations results

--- a/strategy/addition_test.go
+++ b/strategy/addition_test.go
@@ -3,7 +3,7 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestAddition(t *testing.T) {

--- a/strategy/bitsquatting.go
+++ b/strategy/bitsquatting.go
@@ -3,7 +3,7 @@ package strategy
 import (
 	"fmt"
 
-	"zenithar.org/go/typogenerator/helpers"
+	"github.com/Zenithar/typogenerator/helpers"
 )
 
 var (

--- a/strategy/bitsquatting_test.go
+++ b/strategy/bitsquatting_test.go
@@ -3,7 +3,7 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestBitSquatting(t *testing.T) {

--- a/strategy/doublehit.go
+++ b/strategy/doublehit.go
@@ -3,8 +3,8 @@ package strategy
 import (
 	"fmt"
 
-	"zenithar.org/go/typogenerator/helpers"
-	"zenithar.org/go/typogenerator/mapping"
+	"github.com/Zenithar/typogenerator/helpers"
+	"github.com/Zenithar/typogenerator/mapping"
 )
 
 type doublehitStrategy struct {

--- a/strategy/doublehit_test.go
+++ b/strategy/doublehit_test.go
@@ -3,8 +3,8 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/mapping"
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/mapping"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestDoubleHit(t *testing.T) {

--- a/strategy/homoglyph.go
+++ b/strategy/homoglyph.go
@@ -3,7 +3,7 @@ package strategy
 import (
 	"fmt"
 
-	"zenithar.org/go/typogenerator/helpers"
+	"github.com/Zenithar/typogenerator/helpers"
 )
 
 var (

--- a/strategy/homoglyph_test.go
+++ b/strategy/homoglyph_test.go
@@ -3,7 +3,7 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestHomoglyph(t *testing.T) {

--- a/strategy/hyphenation_test.go
+++ b/strategy/hyphenation_test.go
@@ -3,7 +3,7 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestHyphenation(t *testing.T) {

--- a/strategy/omission_test.go
+++ b/strategy/omission_test.go
@@ -3,7 +3,7 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestOmission(t *testing.T) {

--- a/strategy/prefix_test.go
+++ b/strategy/prefix_test.go
@@ -3,7 +3,7 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestPrefix(t *testing.T) {

--- a/strategy/repetition.go
+++ b/strategy/repetition.go
@@ -3,7 +3,7 @@ package strategy
 import (
 	"fmt"
 
-	"zenithar.org/go/typogenerator/helpers"
+	"github.com/Zenithar/typogenerator/helpers"
 )
 
 var (

--- a/strategy/repetition_test.go
+++ b/strategy/repetition_test.go
@@ -3,7 +3,7 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestRepetition(t *testing.T) {

--- a/strategy/replace.go
+++ b/strategy/replace.go
@@ -3,8 +3,8 @@ package strategy
 import (
 	"fmt"
 
-	"zenithar.org/go/typogenerator/helpers"
-	"zenithar.org/go/typogenerator/mapping"
+	"github.com/Zenithar/typogenerator/helpers"
+	"github.com/Zenithar/typogenerator/mapping"
 )
 
 type replaceStrategy struct {

--- a/strategy/replace_test.go
+++ b/strategy/replace_test.go
@@ -3,8 +3,8 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/mapping"
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/mapping"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestReplace(t *testing.T) {

--- a/strategy/similar.go
+++ b/strategy/similar.go
@@ -3,8 +3,8 @@ package strategy
 import (
 	"fmt"
 
-	"zenithar.org/go/typogenerator/helpers"
-	"zenithar.org/go/typogenerator/mapping"
+	"github.com/Zenithar/typogenerator/helpers"
+	"github.com/Zenithar/typogenerator/mapping"
 )
 
 type similarStrategy struct {

--- a/strategy/similar_test.go
+++ b/strategy/similar_test.go
@@ -3,8 +3,8 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/mapping"
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/mapping"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestSimilar(t *testing.T) {

--- a/strategy/subdomain_test.go
+++ b/strategy/subdomain_test.go
@@ -3,7 +3,7 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestSubdomain(t *testing.T) {

--- a/strategy/transposition_test.go
+++ b/strategy/transposition_test.go
@@ -3,7 +3,7 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestTransposition(t *testing.T) {

--- a/strategy/vowelswap_test.go
+++ b/strategy/vowelswap_test.go
@@ -3,7 +3,7 @@ package strategy_test
 import (
 	"testing"
 
-	"zenithar.org/go/typogenerator/strategy"
+	"github.com/Zenithar/typogenerator/strategy"
 )
 
 func TestVowelSwap(t *testing.T) {


### PR DESCRIPTION
This fixes the import paths to not rely on a 3rd party domain.

We (SecurityScorecard) plan on contributing back to this package, if you are open to accepting PRs. As there is no contribution information in the readme for this repository, please let us know if there are any guidelines you would prefer to adhere to.